### PR TITLE
docker-compose pullとdocker-compose upのオプションを修正

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ env:
   global:
     - IMAGE_NAME=yyupw/book-ja-pdf
     - REGISTRY_USER=yyupw
-    - DOCKER_COMPOSE_VERSION=1.25.0
+    - DOCKER_COMPOSE_VERSION=1.24.1
     - secure: "LxOE3hcnO0R3EhD+/1DIrCDR26Xr2h+J8ENVQPWvXAvn0nkDgjJbbUDMXdRQelmTtzG3rHpPfEKRNSg2xhwArkypTJYk1QFLU+uM2/7+WZ0QAz/U+8mM0NtWiLLTq2Wm7/so05qKvqNVGmkRNERks69zvVSb6+v1PlePCgmH+ZlBfKLSv+lwBYgdXQ00fUDdLChLLmv1xPI57i21UIbE4r8PNw/NLz2dYPZbFDxl9UCoCKOc7WmVMXQg8VHf3x6N7wxKQS2auv4MaOugHCkmJ6JmnUdLxlQkUeHcpl22y38TVi6jMBoCf/GkgxneWcgvReZGFDwlNCUoTrUDuqkXf8e6mJ9ViHWvM2YMSx2k98NSqxit3Xxhx+S16p3vDpHeteNNLS3RxcNFsGaZ4b/eaz7WMiV++bGuZ0UISTSTKORyQDJzdzqohrxkRVz7IdBDBQ782h741d+e2cQQtgzoL+LHX47puAnheCHBvUaspYlSKUwGY+9epY+LQXc1Gt/54qLOKpFZmkCg4Ka/pasru2huaZhxl6qr6U32LsZSxMUWA20/G6nRIJfr3IjjmdWUB9a+ecuVw9qpRyOhnj9HOCAyjNV+L8BigW4PRKGqYXVp0hMWq3V0b8CMGVMn+fsjfA3c4GceB6j2GhgUDZoew8bO2rFbYynTPhNxgl398Zg="
     - secure: "AT2+8EVOvmu/xDs9M3qvX1SIeN/vhqxUQJswaTpE7kfS6eVNcRW5B1pswl0/tuyT52PCqRAC+ku2VTl+t4LLRlv3ElxjKBsY971tJ9tPmsayJrnO82mEIIQBemhSILzwMIfM+1VMZES08Wz9nidyFauea9vJlV9CVNVoSHHp2jNDLKOmSEw3QR9izVl4IGoR5L86DyW/2QB3WaJ+VRR1b/KBFKQ4qSsE6WgNlx0wbYm9ASMhrE2iyvDTqyJv0G/F3LDDrahunYlmZzx3Fy0Ey6jKSnM+N1S7y/3UjfQwEn9ABfwzccDmqP7vvGk2LNg7nGRRQXRIMeXY1zs2UH9qHjlNF28ivRGiKratwHtOnOeR0PvO55AobvcmwEdei0OYlenir0q7w7Djwk6J5+mUgmgqblfQMb5QzVkpA+76fBieca5cNN26WJzl5wapxRkx1zw7sOu5bke3Cg9Hi0eUqUGIYSmcoVUdBbzsflzxhdRRvAE0vuAzbxD/VrJ0iKFWnl5mstC3Y1kZgcYq/T5lRwTAY9vIgMfK6g5+6Aylo67fbBj7yVJ1JAp5RbxJIMGcpyxPtRjuhzFTqP5kqO0GIOds4A37k/e+wDurQryGT62c01rIGcUvuhnl5p9WX9peF14IZyIVKItPq1XQB5gRxb5zjt5KN00r4wX2oSu2FIs="
 services:
@@ -20,11 +20,12 @@ before_install:
   - curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > docker-compose
   - chmod +x docker-compose
   - sudo mv docker-compose /usr/local/bin
+  - echo "$REGISTRY_PASSWORD" | docker login -u "$REGISTRY_USER" --password-stdin
 install:
-  - docker-compose pull
+  - docker-compose pull trpl-pdf-compile
   - docker-compose build
 script:
-  - docker-compose up --exit-code-from trpl-pdf-compile
+  - docker-compose up --abort-on-container-exit
 after_success:
   - ./travis/deploy_image.sh
   - ./travis/deploy_pdf.sh

--- a/travis/deploy_image.sh
+++ b/travis/deploy_image.sh
@@ -3,7 +3,6 @@
 set -ex
 
 if [[ "${TRAVIS_OS_NAME}" == "linux" && "${TRAVIS_BRANCH}" == "master" && "${TRAVIS_PULL_REQUEST}" == "false" ]]; then
-  echo "$REGISTRY_PASSWORD" | docker login -u "$REGISTRY_USER" --password-stdin
   docker tag "$IMAGE_NAME" "${IMAGE_NAME}:latest"
   docker push "${IMAGE_NAME}:latest"
 fi


### PR DESCRIPTION
- `docker-compose pull`で正しくイメージがダウンロードされてなかったのでオプションを追加
- `using --exit-code-from implies --abort-on-container-exit`という警告がでていたので`docker-compose up`のオプションを変更