### PR TITLE
Pandocのバージョンを最新にした 

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM pandoc/core:2.7.3
+FROM pandoc/core:2.9.1
 
 MAINTAINER yyu <yyu [at] mental.poker>
 
@@ -32,9 +32,7 @@ ENV PERSISTENT_DEPS \
     git \
     ca-certificates
 
-ENV PANDOC_ROOT /usr/bin/pandoc
-
-ENV PATH $TEXLIVE_PATH/bin/x86_64-linux:$PANDOC_ROOT/bin:$PATH
+ENV PATH $TEXLIVE_PATH/bin/x86_64-linux:$TEXLIVE_PATH/bin/x86_64-linuxmusl:$PATH
 
 RUN apk upgrade --update
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-pandocfilters>=1.3.0
+pandocfilters>=1.4.2


### PR DESCRIPTION
- `docker-compose pull`で正しくイメージがダウンロードされてなかったのでオプションを追加
- `using --exit-code-from implies --abort-on-container-exit`という警告がでていたので`docker-compose up`のオプションを変更