### PR TITLE
Remove `sudo: false` to use Linux infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+os: linux
 dist: bionic
 language: generic
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 dist: bionic
 language: generic
-sudo: required
 env:
   global:
     - IMAGE_NAME=yyupw/book-ja-pdf


### PR DESCRIPTION
- Travis CI requires to remove `sudo: false` option to move into Linux infrastructure. See also:
    - [Upcoming Required Linux Infrastructure Migration](https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration)
- The official document says that Container-based infrastructure has been fully deprecated
    - https://docs.travis-ci.com/user/reference/trusty/#container-based-infrastructure
- So I dropped `sudo: false`