### PR TITLE
Use `--without-gui` option for inkscape

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -30,7 +30,7 @@ do
     SVG=`pwd`/img/${BASH_REMATCH[1]}.svg
     PDF=`pwd`/${BASH_REMATCH[1]}.pdf
     PDFTEX=`pwd`/${BASH_REMATCH[1]}.pdf_tex
-    inkscape -D "$SVG" --export-filename="$PDF" --export-latex
+    inkscape --without-gui -D "$SVG" --export-filename="$PDF" --export-latex
     PAGES=$(egrep -a '/Type /Page\b' "$PDF" | wc -l | tr -d ' ')
     python3 ./python/fix_pdf_tex.py "$PAGES" < "$PDFTEX" > "$PDFTEX.tmp"
     mv "$PDFTEX.tmp" "$PDFTEX"


### PR DESCRIPTION
```
trpl-pdf-compile_1  | + inkscape -D /workdir/img/trpl04-01.svg --export-filename=/workdir/trpl04-01.pdf --export-latex
trpl-pdf-compile_1  | Unable to init server: Could not connect: Connection refused
trpl-pdf-compile_1  | ++ ++ tr -d ' '
```

- https://github.com/rust-lang-ja/book-ja-pdf/runs/7264119710?check_suite_focus=true#step:7:44